### PR TITLE
Show update version in download notification window

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,9 +53,9 @@ const {ipcRenderer} = require('electron');
 const notification = document.getElementById('notification');
 const message = document.getElementById('message');
 const restartButton = document.getElementById('restart-button');
-ipcRenderer.on('update_available', () => {
+ipcRenderer.on('update_available', (version) => {
   ipcRenderer.removeAllListeners('update_available');
-  message.innerText = 'A new update is available. Downloading now...';
+  message.innerText = 'A new update is available, version ' + version + '. Downloading now...';
   notification.classList.remove('hidden');
 });
 ipcRenderer.on('update_downloaded', () => {

--- a/main.js
+++ b/main.js
@@ -194,8 +194,8 @@ function darkMode() {
 
 // Auto update part
 
-autoUpdater.on('update-available', () => {
-    win.webContents.send('update_available');
+autoUpdater.on('update-available', (updateInfo) => {
+    win.webContents.send('update_available', updateInfo.version);
 });
 
 autoUpdater.on('update-downloaded', () => {


### PR DESCRIPTION
This will work assuming that 

win.webContents.send('update_available', updateInfo.version);

Will pass "updateInfo.version" through to the update_available event as an argument. This page shows where I get this updateInfo object from (it apparently is passed during an update-available event from the autoUpdater):
https://www.electron.build/auto-update#updateinfo

If you notice an issue let me know